### PR TITLE
pondr: Prevent double-fetching from the API

### DIFF
--- a/pondr/components/useCohereQuestion.tsx
+++ b/pondr/components/useCohereQuestion.tsx
@@ -24,6 +24,7 @@ export const useCohereQuestion = (
       }
       return response.json();
     },
+    { enabled: typeof relationship !== 'undefined' && typeof setting !== 'undefined' },
   );
 
   return { question: data?.question, isLoading, error };


### PR DESCRIPTION
Previously, react-query would fetch from the API twice because the first render pass was missing query param values from `relationship`, `setting`, and `depth`.

Now setting `enabled` based on the presence of these values ensures the request is made only once when render completes.