### PR TITLE
Replace deprecated classify `medium` model by `embed-english-v2.0`

### DIFF
--- a/pondr/pages/api/generateQuestion.ts
+++ b/pondr/pages/api/generateQuestion.ts
@@ -259,12 +259,12 @@ const generateQuestion = async (req: NextApiRequest, res: NextApiResponse) => {
   const fiveQuestions = parseFiveQuestionsFromGeneration(generations.body['generations']);
 
   const classificationsInterestingness = await cohere.classify({
-    model: 'medium',
+    model: 'embed-english-v2.0',
     examples: INTERESTINGNESS_EXAMPLES,
     inputs: fiveQuestions,
   });
   const classificationsSpecificity = await cohere.classify({
-    model: 'medium',
+    model: 'embed-english-v2.0',
     examples: SPECIFICITY_EXAMPLES,
     inputs: fiveQuestions,
   });


### PR DESCRIPTION
The game live demo fails, with the generateQuestion endpoint sending a 500 back:

<img width="887" alt="image" src="https://github.com/cohere-ai/examples/assets/6030745/73aefa82-a71c-4797-b9f0-335e4d72de3d">

This is because the classify endpoint is called with the deprecated `medium` model.

This should be updated to one of the available models (https://docs.cohere.com/reference/classify) on the classify endpoint, and I think the `embed-english-v2.0` is the most appropriate to replace `medium`.

After the fix, it now works as expected:

<img width="701" alt="image" src="https://github.com/cohere-ai/examples/assets/6030745/832d996d-982f-4310-b334-1c2b2ac91f0d">
